### PR TITLE
feature/client5-credit add tests for credit repository and viewModel

### DIFF
--- a/RichFamily/app/src/test/java/ru/vsu/cs/tp/richfamily/CreditRepositoryTest.kt
+++ b/RichFamily/app/src/test/java/ru/vsu/cs/tp/richfamily/CreditRepositoryTest.kt
@@ -1,0 +1,109 @@
+package ru.vsu.cs.tp.richfamily
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.*
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import retrofit2.Response
+import ru.vsu.cs.tp.richfamily.api.model.credit.Credit
+import ru.vsu.cs.tp.richfamily.api.model.credit.CreditRequestBody
+import ru.vsu.cs.tp.richfamily.api.service.CreditApi
+import ru.vsu.cs.tp.richfamily.repository.CreditRepository
+
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class CreditRepositoryTest {
+
+    lateinit var token: String
+    lateinit var creditRepository: CreditRepository
+
+    @Mock
+    lateinit var creditApi: CreditApi
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        token = "token"
+        creditRepository = CreditRepository(creditApi, "token")
+    }
+
+    @Test
+    fun `should get credit and return true`() {
+        runBlocking {
+            Mockito.`when`(creditApi.getCredits(token))
+                .thenReturn(Response.success(listOf()))
+            val response = creditRepository.getAllCredits().isSuccessful
+            Assert.assertTrue(response)
+        }
+    }
+
+    @Test
+    fun `should delete credit and return true`() {
+        runBlocking {
+            Mockito.`when`(creditApi.deleteCredit(token, 0))
+                .thenReturn(Response.success(null))
+            val response = creditRepository.deleteCredit(token, 0).isSuccessful
+            Assert.assertTrue(response)
+        }
+    }
+
+    @Test
+    fun `should not delete credit and throws NullPointerException`() {
+        runBlocking {
+            Mockito.`when`(creditApi.deleteCredit(token, 0))
+                .thenThrow(NullPointerException::class.java)
+            Assert.assertThrows(NullPointerException::class.java) {
+                runBlocking {
+                    creditRepository.deleteCredit(token, 1).isSuccessful
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should add credit and return true`() {
+        runBlocking {
+            val creditRequestBody = CreditRequestBody(
+                1, "cr_name1",
+                4660.0F, 10, 12, 60.0F, 120.0F, 4780.0F
+            )
+            Mockito.`when`(creditApi.addCredit(token, creditRequestBody))
+                .thenReturn(Response.success(Credit(1, 1, "cr_name1",
+                    4660.0F, 10, 12, 60.0F, 120.0F, 4780.0F)))
+            val response = creditRepository.addCredit(token, creditRequestBody).isSuccessful
+            Assert.assertTrue(response)
+        }
+    }
+
+    @Test
+    fun `should not add credit and return null`() {
+        runBlocking {
+            val creditRequestBody = CreditRequestBody(
+                1, "cr_name1",
+                4660.0F, 10, 12, 60.0F, 120.0F, 4780.0F
+            )
+            Mockito.`when`(creditApi.addCredit(token, creditRequestBody))
+                .thenReturn(Response.success(null))
+            val response = creditRepository.addCredit(token, creditRequestBody).isSuccessful
+            Assert.assertTrue(response)
+        }
+    }
+
+    @Test
+    fun `should add credit not auth and return true`() {
+        runBlocking {
+            val creditRequestBody = CreditRequestBody(
+                1, "cr_name1",
+                4660.0F, 10, 12, 60.0F, 120.0F, 4780.0F
+            )
+            Mockito.`when`(creditApi.addCreditNotAuth(creditRequestBody))
+                .thenReturn(Response.success(null))
+            val response = creditRepository.addCreditNotAuth(creditRequestBody).isSuccessful
+            Assert.assertTrue(response)
+        }
+    }
+}

--- a/RichFamily/app/src/test/java/ru/vsu/cs/tp/richfamily/CreditViewModelTest.kt
+++ b/RichFamily/app/src/test/java/ru/vsu/cs/tp/richfamily/CreditViewModelTest.kt
@@ -1,0 +1,80 @@
+package ru.vsu.cs.tp.richfamily
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import retrofit2.Response
+import ru.vsu.cs.tp.richfamily.api.model.credit.Credit
+import ru.vsu.cs.tp.richfamily.api.service.CreditApi
+import ru.vsu.cs.tp.richfamily.repository.CreditRepository
+import ru.vsu.cs.tp.richfamily.viewmodel.CreditViewModel
+
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class CreditViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    lateinit var creditViewModel: CreditViewModel
+    lateinit var creditRepository: CreditRepository
+
+    @Mock
+    lateinit var creditApi: CreditApi
+
+    @get:Rule
+    val instantTaskExecutionRule: InstantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+        creditRepository = CreditRepository(creditApi, "token")
+        creditViewModel = CreditViewModel(creditRepository, "token")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `get all credit test`(){
+        runBlocking {
+            Mockito.`when`(creditRepository.getAllCredits())
+                .thenReturn(Response.success(listOf(
+                    Credit(1, 1, "cr_name1",
+                        4660.0F, 10, 12, 60.0F, 160.0F, 4820.0F)
+                )))
+            creditViewModel.getAllCredits()
+            val actual = creditViewModel.creditList.getOrAwaitValue()
+            val expected = listOf(
+                Credit(1, 1, "cr_name1",
+                    4660.0F, 10, 12, 60.0F, 160.0F, 4820.0F)
+            )
+            Assert.assertEquals(expected, actual)
+        }
+    }
+    @Test
+    fun `empty credit list test`() {
+        runBlocking {
+            Mockito.`when`(creditRepository.getAllCredits())
+                .thenReturn(Response.success(listOf()))
+            creditViewModel.getAllCredits()
+            val actual = creditViewModel.creditList.getOrAwaitValue()
+            val expected = emptyList<Credit>()
+            Assert.assertEquals(expected, actual)
+        }
+    }
+}


### PR DESCRIPTION
Tests revealed an error in add Credit, the possible reason is the absence of an input check.